### PR TITLE
Nvim 0.10

### DIFF
--- a/.config/nvim/init.lua
+++ b/.config/nvim/init.lua
@@ -154,7 +154,6 @@ local plugins = {
   },
 
   { "tpope/vim-bundler", ft = { "ruby", "eruby" } },
-  { "tpope/vim-commentary", event = "VeryLazy" },
   { "tpope/vim-endwise", ft = { "ruby", "eruby" } },
 
   {

--- a/.config/nvim/init.lua
+++ b/.config/nvim/init.lua
@@ -393,8 +393,6 @@ vim.keymap.set("t", "<C-o>", "<C-\\><C-n>")
 -- LSP and diagnostics
 vim.keymap.set("n", "[d", vim.diagnostic.goto_prev, { desc = "Go to previous diagnostic message" })
 vim.keymap.set("n", "]d", vim.diagnostic.goto_next, { desc = "Go to next diagnostic message" })
-
-vim.keymap.set("n", "K", vim.lsp.buf.hover, { desc = "Hover documentation" })
 vim.keymap.set("n", "gd", vim.lsp.buf.definition, { desc = "Go to definition" })
 
 -- Keymaps: Remap for dealing with word wrap

--- a/.config/nvim/init.lua
+++ b/.config/nvim/init.lua
@@ -50,8 +50,6 @@ end
 vim.opt.rtp:prepend(lazypath)
 
 local plugins = {
-  { "catlee/pull_diags.nvim", event = "LspAttach", opts = {} },
-
   {
     "hrsh7th/nvim-cmp",
     dependencies = {

--- a/.config/nvim/init.lua
+++ b/.config/nvim/init.lua
@@ -391,8 +391,9 @@ vim.keymap.set("t", "<C-l>", "<C-\\><C-n><C-w>l")
 vim.keymap.set("t", "<C-o>", "<C-\\><C-n>")
 
 -- LSP and diagnostics
-vim.keymap.set("n", "[d", vim.diagnostic.goto_prev, { desc = "Go to previous diagnostic message" })
-vim.keymap.set("n", "]d", vim.diagnostic.goto_next, { desc = "Go to next diagnostic message" })
+vim.keymap.set("n", "[d", function() vim.diagnostic.goto_prev({ float = true }) end, { desc = "Diagnostics: prev" })
+vim.keymap.set("n", "]d", function() vim.diagnostic.goto_next({ float = true }) end, { desc = "Diagnostics: next" })
+
 vim.keymap.set("n", "gd", vim.lsp.buf.definition, { desc = "Go to definition" })
 
 -- Keymaps: Remap for dealing with word wrap


### PR DESCRIPTION
- Removed plugins
  - `catlee/pull_diags.nvim`: Neovim 0.10 natively supports textDocument/diagnostic
  - `vim-commentary`: Neovim 0.10 has native support for un/commenting with `gc`
- Removed keymap `K` for `vim.lsp.buf.hover`
- Updated keymaps `]d` and `[d` to automatically open floats. This is how the keymaps used to work, but now these are default keymaps in neovim, but they don't automatically open the floats with warnings.