### PR TITLE
Replace nvim-cmp with native LSP completion

### DIFF
--- a/.config/nvim/init.lua
+++ b/.config/nvim/init.lua
@@ -57,62 +57,7 @@ end
 vim.opt.rtp:prepend(lazypath)
 
 local plugins = {
-  {
-    "hrsh7th/nvim-cmp",
-    dependencies = {
-      "hrsh7th/cmp-nvim-lsp",
-    },
-    config = function()
-      local cmp_autopairs = require("nvim-autopairs.completion.cmp")
-      local cmp = require("cmp")
 
-      cmp.event:on("confirm_done", cmp_autopairs.on_confirm_done())
-
-      cmp.setup {
-        snippet = {
-          expand = function(args)
-            vim.snippet.expand(args.body)
-          end,
-        },
-        mapping = cmp.mapping.preset.insert {
-          ["<C-n>"] = cmp.mapping.select_next_item(),
-          ["<C-p>"] = cmp.mapping.select_prev_item(),
-          ["<C-d>"] = cmp.mapping.scroll_docs(-4),
-          ["<C-f>"] = cmp.mapping.scroll_docs(4),
-          ["<C-Space>"] = cmp.mapping.complete {},
-          ["<CR>"] = cmp.mapping.confirm {
-            behavior = cmp.ConfirmBehavior.Replace,
-            select = true,
-          },
-          ["<Tab>"] = cmp.mapping(function(fallback)
-            if cmp.visible() then
-              cmp.select_next_item()
-            elseif vim.snippet.active({ direction = 1 }) then
-              vim.snippet.jump(1)
-            else
-              fallback()
-            end
-          end, { "i", "s" }),
-          ["<S-Tab>"] = cmp.mapping(function(fallback)
-            if cmp.visible() then
-              cmp.select_prev_item()
-            elseif vim.snippet.active({ direction = -1 }) then
-              vim.snippet.jump(-1)
-            else
-              fallback()
-            end
-          end, { "i", "s" }),
-        },
-        sources = {
-          { name = "copilot" },
-          { name = "nvim_lsp" },
-        },
-        enabled = function()
-          return vim.bo.filetype ~= "markdown"
-        end,
-      }
-    end,
-  },
 
   {
     "ibhagwan/fzf-lua",
@@ -174,9 +119,15 @@ local plugins = {
         automatic_enable = true,
       })
 
-      local capabilities = vim.lsp.protocol.make_client_capabilities()
-      capabilities = require("cmp_nvim_lsp").default_capabilities(capabilities)
-      vim.lsp.config("*", { capabilities = capabilities })
+      vim.lsp.config("*", {
+        capabilities = {
+          textDocument = {
+            completion = {
+              completionItem = { snippetSupport = true },
+            },
+          },
+        },
+      })
 
       vim.lsp.config("ruby_lsp", {
         cmd = { "ruby-lsp" },
@@ -336,21 +287,14 @@ local plugins = {
 
 
   {
-    "zbirenbaum/copilot-cmp",
+    "zbirenbaum/copilot.lua",
     event = "InsertEnter",
-    config = function() require("copilot_cmp").setup() end,
-    dependencies = {
-      {
-        "zbirenbaum/copilot.lua",
-        cmd = "Copilot",
-        config = function()
-          require("copilot").setup({
-            suggestion = { enabled = false },
-            panel = { enabled = false },
-          })
-        end,
-      },
-    },
+    config = function()
+      require("copilot").setup({
+        suggestion = { enabled = true, auto_trigger = true },
+        panel = { enabled = false },
+      })
+    end,
   },
 }
 
@@ -369,6 +313,35 @@ vim.api.nvim_create_autocmd("FileType", {
     end
   end,
 })
+
+-- Native LSP completion
+vim.api.nvim_create_autocmd("LspAttach", {
+  callback = function(args)
+    local client = vim.lsp.get_client_by_id(args.data.client_id)
+    if client:supports_method("textDocument/completion") then
+      vim.lsp.completion.enable(true, client.id, args.buf, { autotrigger = true })
+    end
+  end,
+})
+
+vim.keymap.set("i", "<CR>", function()
+  if vim.fn.pumvisible() == 1 then return "<C-y>" end
+  return "<CR>"
+end, { expr = true })
+
+vim.keymap.set("i", "<Tab>", function()
+  local copilot = require("copilot.suggestion")
+  if vim.fn.pumvisible() == 1 then return "<C-n>" end
+  if copilot.is_visible() then copilot.accept(); return "" end
+  if vim.snippet.active({ direction = 1 }) then vim.snippet.jump(1); return "" end
+  return "<Tab>"
+end, { expr = true })
+
+vim.keymap.set("i", "<S-Tab>", function()
+  if vim.fn.pumvisible() == 1 then return "<C-p>" end
+  if vim.snippet.active({ direction = -1 }) then vim.snippet.jump(-1); return "" end
+  return "<S-Tab>"
+end, { expr = true })
 
 vim.diagnostic.config({
   underline = { severity = { max = vim.diagnostic.severity.INFO } },

--- a/.config/nvim/init.lua
+++ b/.config/nvim/init.lua
@@ -181,16 +181,26 @@ local plugins = {
       vim.lsp.config("ruby_lsp", {
         cmd = { "ruby-lsp" },
         filetypes = { "ruby", "eruby" },
-        root_dir = vim.fs.dirname(vim.fs.find({ "Gemfile", ".git" }, { upward = true })[1]),
+        root_dir = function(bufnr, on_dir)
+          local bufname = vim.api.nvim_buf_get_name(bufnr)
+          local found = vim.fs.find({ "Gemfile", ".git" }, { upward = true, path = vim.fs.dirname(bufname) })[1]
+          if found then
+            on_dir(vim.fs.dirname(found))
+          end
+        end,
       })
       vim.lsp.enable("ruby_lsp")
 
       vim.lsp.config("sorbet", {
         cmd = { "srb", "tc", "--lsp" },
         filetypes = { "ruby" },
-        root_dir = vim.fs.dirname(
-          vim.fs.dirname(vim.fs.find("sorbet/config", { upward = true })[1])
-        ),
+        root_dir = function(bufnr, on_dir)
+          local bufname = vim.api.nvim_buf_get_name(bufnr)
+          local found = vim.fs.find("sorbet/config", { upward = true, path = vim.fs.dirname(bufname) })[1]
+          if found then
+            on_dir(vim.fs.dirname(vim.fs.dirname(found)))
+          end
+        end,
       })
       vim.lsp.enable("sorbet")
 


### PR DESCRIPTION
- Remove nvim-cmp, cmp-nvim-lsp, copilot-cmp (3 plugins)
- Use vim.lsp.completion (built-in since Neovim 0.12)
- Switch copilot to inline ghost text (Tab to accept)
- Tab/S-Tab/CR keymaps for popup navigation