### PR TITLE
Add shared /pr command

### DIFF
--- a/agents/common/commands/pr.md
+++ b/agents/common/commands/pr.md
@@ -1,0 +1,32 @@
+Create a GitHub PR from the current repo changes.
+
+Follow this workflow:
+
+1. Inspect the repo state first:
+   - current directory, branch, remotes, and git status
+   - staged and unstaged diffs
+   - recent commits if needed for context
+   - any repo-specific AGENTS.md or project instructions that affect git/PR workflow
+2. If currently on the main branch, create a new branch based on the changes before committing.
+   - Pick a concise, descriptive branch name from the diff.
+   - Use kebab-case only.
+   - Do not include slashes.
+   - Do not include my name.
+3. If there are uncommitted changes, stage the intended changes and create a concise commit.
+   - If the working tree contains clearly unrelated changes, stop and ask what to include.
+   - Do not amend existing commits unless explicitly requested.
+4. Push the branch using the repo's conventions.
+   - Follow any repo-specific git workflow instructions you discovered.
+   - Never force-push unless explicitly requested.
+5. Create a draft PR unless I explicitly ask for ready-for-review.
+6. Write a clear, useful PR description based on the actual diff.
+   - Explain what changed and why.
+   - Keep it concise and concrete.
+   - Link relevant issues if they are obvious from the branch, commit, or context.
+   - Only include a Testing section if there was manual testing or something unusual/non-obvious to test.
+   - Do not add a Testing section just to list checks that normal CI will catch.
+7. Return the full PR URL.
+
+Use any extra context I pass after /pr as guidance, but verify it against the diff.
+
+Extra context: $ARGUMENTS

--- a/install.sh
+++ b/install.sh
@@ -64,9 +64,10 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
   ln -sf ~/dotfiles/.config/zellij/config.kdl ~/.config/zellij/config.kdl
 
   current_status "Setting up Claude config"
-  mkdir -p ~/.claude
+  mkdir -p ~/.claude/commands
   ln -sf ~/dotfiles/agents/claude/settings.json ~/.claude/settings.json
   ln -sf ~/dotfiles/agents/claude/statusline-command.sh ~/.claude/statusline-command.sh
+  ln -sf ~/dotfiles/agents/common/commands/pr.md ~/.claude/commands/pr.md
 
   current_status "Setting up Obsidian backup"
   mkdir -p ~/Documents/backups/obsidian
@@ -102,9 +103,10 @@ mkdir -p ~/.config/irb
 ln -sf ~/dotfiles/.config/irb/irbrc ~/.config/irb/irbrc
 
 current_status "Setting up Pi config"
-mkdir -p ~/.pi/agent/extensions ~/.pi/agent/themes
+mkdir -p ~/.pi/agent/extensions ~/.pi/agent/prompts ~/.pi/agent/themes
 ln -sf ~/dotfiles/agents/pi/extensions/status-line.ts ~/.pi/agent/extensions/status-line.ts
 ln -sfn ~/dotfiles/agents/pi/extensions/diff-panel ~/.pi/agent/extensions/diff-panel
+ln -sf ~/dotfiles/agents/common/commands/pr.md ~/.pi/agent/prompts/pr.md
 ln -sf ~/dotfiles/agents/pi/settings.json ~/.pi/agent/settings.json
 ln -sf ~/dotfiles/agents/pi/themes/nightowl.json ~/.pi/agent/themes/nightowl.json
 


### PR DESCRIPTION
## What

Add a shared `/pr` command prompt for creating draft GitHub PRs from the current repo changes. The prompt tells the agent to inspect the diff, create a branch when needed, commit and push the intended changes, and write a concise PR description.

The installer links the same shared command into both Claude commands and Pi prompt templates so the workflow stays in one place.