### PR TITLE
Add Windows + WSL2 setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,11 @@ gh auth login
 
 On Windows, run `windows/windows_setup.ps1` as Administrator before the steps above. This installs WSL2, WezTerm, win32yank, Obsidian, Cursor, and JetBrains Mono Nerd Font. Reboot if prompted, then follow the steps above inside the WSL2 Ubuntu terminal.
 
+```powershell
+Set-ExecutionPolicy Bypass -Scope Process -Force
+.\windows\windows_setup.ps1
+```
+
 `install.sh` detects WSL2 and handles apt packages, Rust, mise, Claude Code, and the win32yank Neovim clipboard bridge automatically.
 
 ## Agent config

--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ On Windows, run `windows/windows_setup.ps1` as Administrator before the steps ab
 
 ```powershell
 Set-ExecutionPolicy Bypass -Scope Process -Force
-.\windows\windows_setup.ps1
+Invoke-WebRequest -Uri "https://raw.githubusercontent.com/nithinbekal/dotfiles/main/windows/windows_setup.ps1" -OutFile "$env:TEMP\windows_setup.ps1"
+& "$env:TEMP\windows_setup.ps1"
 ```
 
 `install.sh` detects WSL2 and handles apt packages, Rust, mise, Claude Code, and the win32yank Neovim clipboard bridge automatically.


### PR DESCRIPTION
## Summary

- Adds `windows/windows_setup.ps1` to install WSL2, WezTerm, win32yank, Obsidian, Cursor, LM Studio, and JetBrains Mono Nerd Font via winget
- Extends `install.sh` to detect WSL2 and handle apt packages, Rust via rustup, Homebrew (with `--no-cask` on WSL2), clipboard bridge, Claude Code, and Pi coding agent
- Moves tmux, Zellij, and Claude config setup out of the macOS-only block so they run on all platforms
- Adds new machine setup section to README with SSH key, git config, clone, and Windows-specific instructions

---
_Generated by [Claude Code](https://claude.ai/code/session_01HFohxibGZ31x7Mihm5LSMp)_