### PR TITLE
Fix Invoke-WebRequest mangling downloaded script

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ On Windows, run `windows/windows_setup.ps1` as Administrator before the steps ab
 
 ```powershell
 Set-ExecutionPolicy Bypass -Scope Process -Force
-Invoke-WebRequest -Uri "https://raw.githubusercontent.com/nithinbekal/dotfiles/main/windows/windows_setup.ps1" -OutFile "$env:TEMP\windows_setup.ps1"
+Invoke-WebRequest -Uri "https://raw.githubusercontent.com/nithinbekal/dotfiles/main/windows/windows_setup.ps1" -OutFile "$env:TEMP\windows_setup.ps1" -UseBasicParsing
 & "$env:TEMP\windows_setup.ps1"
 ```
 


### PR DESCRIPTION
## Problem

Without `-UseBasicParsing`, `Invoke-WebRequest` uses the IE engine which can transform plain text content — auto-linking filenames like `install.sh` into `[install.sh](http://install.sh)`, which corrupts the saved `.ps1` file and causes a PowerShell parse error.

## Fix

Add `-UseBasicParsing` to the `Invoke-WebRequest` command in the README. This bypasses the IE engine and downloads the file as raw bytes.

https://claude.ai/code/session_01HFohxibGZ31x7Mihm5LSMp

---
_Generated by [Claude Code](https://claude.ai/code/session_01HFohxibGZ31x7Mihm5LSMp)_