### PR TITLE
Fix windows_setup.ps1 parse error on PowerShell 5.1

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.ps1 text eol=crlf

--- a/windows/windows_setup.ps1
+++ b/windows/windows_setup.ps1
@@ -4,7 +4,7 @@ Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"
 
 function Write-Status($msg) {
-  Write-Host "⭑ $msg" -ForegroundColor Yellow
+  Write-Host "* $msg" -ForegroundColor Yellow
 }
 
 Write-Status "Installing WSL2"
@@ -61,7 +61,7 @@ if ($alreadyInstalled) {
 }
 
 Write-Host ""
-Write-Host "✓ Windows setup complete." -ForegroundColor Green
+Write-Host "Done. Windows setup complete." -ForegroundColor Green
 Write-Host ""
 Write-Host "Next steps:" -ForegroundColor Cyan
 Write-Host "  1. Reboot if WSL2 was just installed for the first time."


### PR DESCRIPTION
## Problem

PowerShell 5.1 (the version bundled with Windows) reads UTF-8 files without a BOM as ANSI encoding. The script contained two non-ASCII characters — `⭑` (U+2B51) and `✓` (U+2713) — whose multi-byte UTF-8 sequences get misinterpreted, causing the parser to lose sync and report a spurious `TerminatorExpectedAtEndOfString` error at line 69.

## Fix

- Replace `⭑` with `*` in the `Write-Status` helper
- Replace `✓` with `Done.` in the success message
- Convert file to CRLF line endings and add `.gitattributes` to enforce this for all `.ps1` files
- Add `-UseBasicParsing` to the `Invoke-WebRequest` command in the README

The file is now pure ASCII with CRLF line terminators, fully compatible with PowerShell 5.1.

https://claude.ai/code/session_01HFohxibGZ31x7Mihm5LSMp

---
_Generated by [Claude Code](https://claude.ai/code/session_01HFohxibGZ31x7Mihm5LSMp)_