### PR TITLE
Fix Windows setup script issues

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -51,7 +51,7 @@ fi
 
 current_status "Installing dependencies via Brewfile"
 if is_wsl2; then
-  brew bundle --file=~/dotfiles/Brewfile --no-cask
+  grep -v '^cask' ~/dotfiles/Brewfile | brew bundle --file=/dev/stdin
 else
   brew bundle --file=~/dotfiles/Brewfile
 fi

--- a/windows/windows_setup.ps1
+++ b/windows/windows_setup.ps1
@@ -48,12 +48,14 @@ if ($alreadyInstalled) {
   Invoke-WebRequest -Uri $releaseUrl -OutFile $tmpZip -UseBasicParsing
   Expand-Archive -Path $tmpZip -DestinationPath $tmpDir -Force
 
-  $fontFiles = Get-ChildItem $tmpDir -Filter "*.ttf" |
-    Where-Object { $_.Name -notmatch "Windows Compatible" }
+  $fontFiles = Get-ChildItem $tmpDir -Filter "JetBrainsMonoNerdFont-*.ttf"
 
-  $shellFonts = (New-Object -ComObject Shell.Application).Namespace(0x14)
+  New-Item -ItemType Directory -Force -Path $fontsDir | Out-Null
   foreach ($font in $fontFiles) {
-    $shellFonts.CopyHere($font.FullName, 0x10)
+    Copy-Item $font.FullName $fontsDir -Force
+    New-ItemProperty -Path "HKCU:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Fonts" `
+      -Name "$($font.BaseName) (TrueType)" -Value "$fontsDir\$($font.Name)" `
+      -Force | Out-Null
   }
 
   Remove-Item $tmpZip, $tmpDir -Recurse -Force


### PR DESCRIPTION
## Changes

- Fix `windows_setup.ps1` parse error on PowerShell 5.1 by replacing non-ASCII characters (`⭑`, `✓`) with ASCII equivalents — PS 5.1 reads UTF-8 without BOM as ANSI, causing multi-byte characters to break parsing
- Add `.gitattributes` to enforce CRLF line endings for `.ps1` files
- Add `-UseBasicParsing` to `Invoke-WebRequest` in README to prevent IE engine mangling downloads
- Speed up font installation by replacing slow `CopyHere` shell method with direct file copy + registry registration, filtered to `JetBrainsMonoNerdFont-*` variants only
- Fix `brew bundle` on WSL2 — `--no-cask` is not a valid flag; filter cask lines with `grep` instead

https://claude.ai/code/session_01HFohxibGZ31x7Mihm5LSMp

---
_Generated by [Claude Code](https://claude.ai/code/session_01HFohxibGZ31x7Mihm5LSMp)_